### PR TITLE
Implement iOS auth and onboarding wizard for Issue #4

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,93 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+Packages/
+Package.pins
+Package.resolved
+*.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+.swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+*.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+# Mac OS
+.DS_Store

--- a/ios/HousePulseLite/HousePulseLite/Config/SupabaseConfig.swift
+++ b/ios/HousePulseLite/HousePulseLite/Config/SupabaseConfig.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct SupabaseConfig {
+    static let url = "YOUR_SUPABASE_URL" // Replace with actual URL
+    static let anonKey = "YOUR_SUPABASE_ANON_KEY" // Replace with actual key
+
+    static let functionsURL = "\(url)/functions/v1"
+}

--- a/ios/HousePulseLite/HousePulseLite/HousePulseLiteApp.swift
+++ b/ios/HousePulseLite/HousePulseLite/HousePulseLiteApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct HousePulseLiteApp: App {
+    @StateObject private var authViewModel = AuthViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(authViewModel)
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Info.plist
+++ b/ios/HousePulseLite/HousePulseLite/Info.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>HousePulse Lite</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Automatic</string>
+</dict>
+</plist>

--- a/ios/HousePulseLite/HousePulseLite/Models/APIModels.swift
+++ b/ios/HousePulseLite/HousePulseLite/Models/APIModels.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+// MARK: - Pair Home
+struct PairHomeRequest: Codable {
+    let homeId: String
+    let mcpApiKey: String
+
+    enum CodingKeys: String, CodingKey {
+        case homeId = "home_id"
+        case mcpApiKey = "mcp_api_key"
+    }
+}
+
+struct PairHomeResponse: Codable {
+    let paired: Bool
+}
+
+// MARK: - System Check
+struct SystemCheckRequest: Codable {
+    let homeId: String
+
+    enum CodingKeys: String, CodingKey {
+        case homeId = "home_id"
+    }
+}
+
+struct SystemCheckResponse: Codable {
+    let ok: Bool
+    let lastDataTs: String
+    let notes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case lastDataTs = "last_data_ts"
+        case notes
+    }
+}
+
+// MARK: - Error Response
+struct APIError: Codable {
+    let error: String
+}

--- a/ios/HousePulseLite/HousePulseLite/Models/Home.swift
+++ b/ios/HousePulseLite/HousePulseLite/Models/Home.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct Home: Identifiable, Codable {
+    let id: UUID
+    let name: String
+    let address: String?
+
+    init(id: UUID = UUID(), name: String, address: String? = nil) {
+        self.id = id
+        self.name = name
+        self.address = address
+    }
+}
+
+extension Home {
+    // Mock homes for MVP
+    static let mockHomes: [Home] = [
+        Home(name: "My Home", address: "123 Main St"),
+        Home(name: "Vacation House", address: "456 Beach Rd"),
+        Home(name: "Apartment", address: "789 City Ave")
+    ]
+}

--- a/ios/HousePulseLite/HousePulseLite/Models/User.swift
+++ b/ios/HousePulseLite/HousePulseLite/Models/User.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct User: Codable {
+    let id: String
+    let email: String?
+    let appMetadata: [String: AnyCodable]?
+    let userMetadata: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case email
+        case appMetadata = "app_metadata"
+        case userMetadata = "user_metadata"
+    }
+}
+
+// Helper for dynamic JSON
+struct AnyCodable: Codable {
+    let value: Any
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let string = try? container.decode(String.self) {
+            value = string
+        } else if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let double = try? container.decode(Double.self) {
+            value = double
+        } else {
+            value = ""
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        if let int = value as? Int {
+            try container.encode(int)
+        } else if let string = value as? String {
+            try container.encode(string)
+        } else if let bool = value as? Bool {
+            try container.encode(bool)
+        } else if let double = value as? Double {
+            try container.encode(double)
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Services/KeychainService.swift
+++ b/ios/HousePulseLite/HousePulseLite/Services/KeychainService.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Security
+
+class KeychainService {
+    static let shared = KeychainService()
+
+    private let service = "com.housepulse.lite"
+
+    private init() {}
+
+    // Save API key to Keychain
+    func saveMCPApiKey(_ apiKey: String, for homeId: String) -> Bool {
+        let account = "mcp_api_key_\(homeId)"
+
+        // Delete existing key if present
+        delete(account: account)
+
+        guard let data = apiKey.data(using: .utf8) else {
+            return false
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    // Retrieve API key from Keychain
+    func getMCPApiKey(for homeId: String) -> String? {
+        let account = "mcp_api_key_\(homeId)"
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let apiKey = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return apiKey
+    }
+
+    // Delete API key from Keychain
+    func deleteMCPApiKey(for homeId: String) -> Bool {
+        let account = "mcp_api_key_\(homeId)"
+        return delete(account: account)
+    }
+
+    private func delete(account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Services/SupabaseService.swift
+++ b/ios/HousePulseLite/HousePulseLite/Services/SupabaseService.swift
@@ -1,0 +1,168 @@
+import Foundation
+import AuthenticationServices
+
+class SupabaseService {
+    static let shared = SupabaseService()
+
+    private let url: String
+    private let anonKey: String
+    private var accessToken: String?
+
+    private init() {
+        self.url = SupabaseConfig.url
+        self.anonKey = SupabaseConfig.anonKey
+    }
+
+    // MARK: - Authentication
+
+    func signInWithApple(identityToken: String, nonce: String) async throws -> User {
+        let endpoint = "\(url)/auth/v1/token?grant_type=id_token"
+
+        var request = URLRequest(url: URL(string: endpoint)!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(anonKey, forHTTPHeaderField: "apikey")
+
+        let body: [String: Any] = [
+            "provider": "apple",
+            "id_token": identityToken,
+            "nonce": nonce
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw SupabaseError.authenticationFailed
+        }
+
+        let authResponse = try JSONDecoder().decode(AuthResponse.self, from: data)
+        self.accessToken = authResponse.accessToken
+
+        return authResponse.user
+    }
+
+    func signInWithEmail(email: String, password: String) async throws -> User {
+        let endpoint = "\(url)/auth/v1/token?grant_type=password"
+
+        var request = URLRequest(url: URL(string: endpoint)!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(anonKey, forHTTPHeaderField: "apikey")
+
+        let body: [String: String] = [
+            "email": email,
+            "password": password
+        ]
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw SupabaseError.authenticationFailed
+        }
+
+        let authResponse = try JSONDecoder().decode(AuthResponse.self, from: data)
+        self.accessToken = authResponse.accessToken
+
+        return authResponse.user
+    }
+
+    func signOut() {
+        accessToken = nil
+    }
+
+    // MARK: - Edge Functions
+
+    func pairHome(homeId: String, mcpApiKey: String) async throws -> PairHomeResponse {
+        guard let token = accessToken else {
+            throw SupabaseError.notAuthenticated
+        }
+
+        let endpoint = "\(SupabaseConfig.functionsURL)/pair_home"
+        var request = URLRequest(url: URL(string: endpoint)!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(anonKey, forHTTPHeaderField: "apikey")
+
+        let body = PairHomeRequest(homeId: homeId, mcpApiKey: mcpApiKey)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SupabaseError.networkError
+        }
+
+        if httpResponse.statusCode == 200 {
+            return try JSONDecoder().decode(PairHomeResponse.self, from: data)
+        } else {
+            let error = try? JSONDecoder().decode(APIError.self, from: data)
+            throw SupabaseError.apiError(error?.error ?? "Unknown error")
+        }
+    }
+
+    func systemCheck(homeId: String) async throws -> SystemCheckResponse {
+        guard let token = accessToken else {
+            throw SupabaseError.notAuthenticated
+        }
+
+        let endpoint = "\(SupabaseConfig.functionsURL)/system_check"
+        var request = URLRequest(url: URL(string: endpoint)!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(anonKey, forHTTPHeaderField: "apikey")
+
+        let body = SystemCheckRequest(homeId: homeId)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SupabaseError.networkError
+        }
+
+        if httpResponse.statusCode == 200 {
+            return try JSONDecoder().decode(SystemCheckResponse.self, from: data)
+        } else {
+            let error = try? JSONDecoder().decode(APIError.self, from: data)
+            throw SupabaseError.apiError(error?.error ?? "Unknown error")
+        }
+    }
+}
+
+// MARK: - Supporting Types
+
+struct AuthResponse: Codable {
+    let accessToken: String
+    let user: User
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case user
+    }
+}
+
+enum SupabaseError: LocalizedError {
+    case authenticationFailed
+    case notAuthenticated
+    case networkError
+    case apiError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .authenticationFailed:
+            return "Authentication failed. Please try again."
+        case .notAuthenticated:
+            return "Not authenticated. Please sign in."
+        case .networkError:
+            return "Network error. Please check your connection."
+        case .apiError(let message):
+            return message
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/ViewModels/AuthViewModel.swift
+++ b/ios/HousePulseLite/HousePulseLite/ViewModels/AuthViewModel.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftUI
+import AuthenticationServices
+import CryptoKit
+
+@MainActor
+class AuthViewModel: ObservableObject {
+    @Published var isAuthenticated = false
+    @Published var currentUser: User?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let supabaseService = SupabaseService.shared
+    private var currentNonce: String?
+
+    // Sign in with Apple
+    func signInWithApple(authorization: ASAuthorization) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                  let identityToken = appleIDCredential.identityToken,
+                  let tokenString = String(data: identityToken, encoding: .utf8),
+                  let nonce = currentNonce else {
+                throw SupabaseError.authenticationFailed
+            }
+
+            let user = try await supabaseService.signInWithApple(
+                identityToken: tokenString,
+                nonce: nonce
+            )
+
+            currentUser = user
+            isAuthenticated = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // Sign in with email/password
+    func signInWithEmail(email: String, password: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let user = try await supabaseService.signInWithEmail(
+                email: email,
+                password: password
+            )
+
+            currentUser = user
+            isAuthenticated = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // Sign out
+    func signOut() {
+        supabaseService.signOut()
+        currentUser = nil
+        isAuthenticated = false
+    }
+
+    // Generate nonce for Apple Sign In
+    func generateNonce() -> String {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        return sha256(nonce)
+    }
+
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+
+        return hashString
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/ViewModels/OnboardingViewModel.swift
+++ b/ios/HousePulseLite/HousePulseLite/ViewModels/OnboardingViewModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class OnboardingViewModel: ObservableObject {
+    @Published var selectedHome: Home?
+    @Published var mcpApiKey: String = ""
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var isPaired = false
+    @Published var systemCheckResponse: SystemCheckResponse?
+
+    private let supabaseService = SupabaseService.shared
+    private let keychainService = KeychainService.shared
+
+    // Step 1: Select home (mock data)
+    let availableHomes = Home.mockHomes
+
+    // Step 2: Pair home with MCP API key
+    func pairHome() async {
+        guard let home = selectedHome else {
+            errorMessage = "Please select a home"
+            return
+        }
+
+        guard !mcpApiKey.isEmpty else {
+            errorMessage = "Please enter your MCP API key"
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            // Call pair_home edge function
+            let response = try await supabaseService.pairHome(
+                homeId: home.id.uuidString,
+                mcpApiKey: mcpApiKey
+            )
+
+            if response.paired {
+                // Store API key securely in Keychain
+                let saved = keychainService.saveMCPApiKey(
+                    mcpApiKey,
+                    for: home.id.uuidString
+                )
+
+                if !saved {
+                    throw SupabaseError.apiError("Failed to save API key securely")
+                }
+
+                // Verify pairing with system_check
+                try await performSystemCheck()
+            } else {
+                errorMessage = "Pairing failed. Please try again."
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // Step 3: Verify system with system_check
+    func performSystemCheck() async throws {
+        guard let home = selectedHome else {
+            throw SupabaseError.apiError("No home selected")
+        }
+
+        let response = try await supabaseService.systemCheck(
+            homeId: home.id.uuidString
+        )
+
+        if response.ok {
+            systemCheckResponse = response
+            isPaired = true
+        } else {
+            throw SupabaseError.apiError("System check failed")
+        }
+    }
+
+    // Retry pairing flow
+    func retry() {
+        errorMessage = nil
+        systemCheckResponse = nil
+    }
+
+    // Reset onboarding
+    func reset() {
+        selectedHome = nil
+        mcpApiKey = ""
+        errorMessage = nil
+        isPaired = false
+        systemCheckResponse = nil
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/MainAppView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/MainAppView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct MainAppView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                // Success header
+                VStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 80))
+                        .foregroundColor(.green)
+
+                    Text("Welcome to HousePulse!")
+                        .font(.title)
+                        .fontWeight(.bold)
+
+                    if let home = onboardingViewModel.selectedHome {
+                        Text("Connected to \(home.name)")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+
+                // System status
+                if let systemCheck = onboardingViewModel.systemCheckResponse {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("System Status")
+                            .font(.headline)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            StatusRow(
+                                icon: "checkmark.circle.fill",
+                                text: "System OK",
+                                color: .green
+                            )
+
+                            StatusRow(
+                                icon: "clock.fill",
+                                text: "Last updated: \(formatDate(systemCheck.lastDataTs))",
+                                color: .blue
+                            )
+
+                            ForEach(systemCheck.notes, id: \.self) { note in
+                                StatusRow(
+                                    icon: "info.circle.fill",
+                                    text: note,
+                                    color: .blue
+                                )
+                            }
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.systemGray6))
+                    .cornerRadius(12)
+                    .padding(.horizontal)
+                }
+
+                Spacer()
+
+                // Placeholder for future features
+                VStack(spacing: 16) {
+                    Text("Main app features coming soon!")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Text("Chat, sensor monitoring, and more will be available here.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding()
+
+                Spacer()
+
+                // Sign out button
+                Button(action: {
+                    authViewModel.signOut()
+                    onboardingViewModel.reset()
+                }) {
+                    Text("Sign Out")
+                        .foregroundColor(.red)
+                }
+                .padding()
+            }
+            .navigationTitle("Home")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func formatDate(_ isoString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: isoString) else {
+            return isoString
+        }
+
+        let displayFormatter = DateFormatter()
+        displayFormatter.dateStyle = .short
+        displayFormatter.timeStyle = .short
+        return displayFormatter.string(from: date)
+    }
+}
+
+struct StatusRow: View {
+    let icon: String
+    let text: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundColor(color)
+                .frame(width: 24)
+
+            Text(text)
+                .font(.subheadline)
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/OnboardingFlowView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/OnboardingFlowView.swift
@@ -1,0 +1,280 @@
+import SwiftUI
+
+struct OnboardingFlowView: View {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @State private var currentStep = 0
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                // Progress indicator
+                ProgressView(value: Double(currentStep), total: 2)
+                    .padding()
+
+                TabView(selection: $currentStep) {
+                    // Step 1: Home Selection
+                    HomeSelectionView(currentStep: $currentStep)
+                        .tag(0)
+
+                    // Step 2: MCP Key Entry and Pairing
+                    MCPKeyEntryView(currentStep: $currentStep)
+                        .tag(1)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .disabled(onboardingViewModel.isLoading)
+            }
+            .navigationTitle("Setup")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+// MARK: - Home Selection View
+struct HomeSelectionView: View {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @Binding var currentStep: Int
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Header
+            VStack(spacing: 8) {
+                Image(systemName: "house.circle.fill")
+                    .font(.system(size: 60))
+                    .foregroundColor(.blue)
+
+                Text("Select Your Home")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text("Choose the home you want to pair with HousePulse")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding()
+
+            // Home list
+            List(onboardingViewModel.availableHomes) { home in
+                Button(action: {
+                    onboardingViewModel.selectedHome = home
+                }) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(home.name)
+                                .font(.headline)
+                            if let address = home.address {
+                                Text(address)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+
+                        Spacer()
+
+                        if onboardingViewModel.selectedHome?.id == home.id {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.blue)
+                        }
+                    }
+                }
+                .foregroundColor(.primary)
+            }
+
+            // Continue button
+            Button(action: {
+                withAnimation {
+                    currentStep = 1
+                }
+            }) {
+                Text("Continue")
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(onboardingViewModel.selectedHome != nil ? Color.blue : Color.gray)
+                    .cornerRadius(12)
+            }
+            .disabled(onboardingViewModel.selectedHome == nil)
+            .padding()
+        }
+    }
+}
+
+// MARK: - MCP Key Entry View
+struct MCPKeyEntryView: View {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Binding var currentStep: Int
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 8) {
+                    Image(systemName: "key.fill")
+                        .font(.system(size: 60))
+                        .foregroundColor(.blue)
+
+                    Text("Enter MCP API Key")
+                        .font(.title2)
+                        .fontWeight(.bold)
+
+                    Text("This key will be securely stored and used to connect your home")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding()
+
+                // Selected home info
+                if let home = onboardingViewModel.selectedHome {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Selected Home")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        HStack {
+                            Image(systemName: "house.fill")
+                                .foregroundColor(.blue)
+                            Text(home.name)
+                                .font(.headline)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(8)
+                    }
+                    .padding(.horizontal)
+                }
+
+                // API Key input
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("MCP API Key")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    SecureField("Enter your MCP API key", text: $onboardingViewModel.mcpApiKey)
+                        .textContentType(.password)
+                        .padding()
+                        .background(Color(.systemGray6))
+                        .cornerRadius(8)
+
+                    Text("Your API key will be encrypted and stored securely in the iOS Keychain")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal)
+
+                // Error message
+                if let errorMessage = onboardingViewModel.errorMessage {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.red)
+                        Text(errorMessage)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.red.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                }
+
+                // Success message
+                if onboardingViewModel.isPaired,
+                   let systemCheck = onboardingViewModel.systemCheckResponse {
+                    VStack(spacing: 12) {
+                        HStack {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                                .font(.title)
+                            Text("Pairing Successful!")
+                                .font(.headline)
+                                .foregroundColor(.green)
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("System Status")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+
+                            ForEach(systemCheck.notes, id: \.self) { note in
+                                HStack {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.green)
+                                        .font(.caption)
+                                    Text(note)
+                                        .font(.caption)
+                                }
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.green.opacity(0.1))
+                        .cornerRadius(8)
+                    }
+                    .padding()
+                }
+
+                // Action buttons
+                VStack(spacing: 12) {
+                    if onboardingViewModel.isPaired {
+                        // Success - button to continue to app (will be handled by RootView)
+                        Text("Setup complete! Loading your home...")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .padding()
+                    } else {
+                        // Pair Home button
+                        Button(action: {
+                            Task {
+                                await onboardingViewModel.pairHome()
+                            }
+                        }) {
+                            HStack {
+                                if onboardingViewModel.isLoading {
+                                    ProgressView()
+                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                } else {
+                                    Text("Pair Home")
+                                        .fontWeight(.semibold)
+                                }
+                            }
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                            .background(Color.blue)
+                            .cornerRadius(12)
+                        }
+                        .disabled(onboardingViewModel.mcpApiKey.isEmpty || onboardingViewModel.isLoading)
+
+                        // Back button
+                        Button(action: {
+                            withAnimation {
+                                currentStep = 0
+                            }
+                        }) {
+                            Text("Back")
+                                .foregroundColor(.blue)
+                        }
+                        .disabled(onboardingViewModel.isLoading)
+
+                        // Retry button (if error)
+                        if onboardingViewModel.errorMessage != nil {
+                            Button(action: {
+                                onboardingViewModel.retry()
+                            }) {
+                                Text("Retry")
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                    }
+                }
+                .padding()
+
+                Spacer()
+            }
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/RootView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/RootView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @StateObject private var onboardingViewModel = OnboardingViewModel()
+
+    var body: some View {
+        Group {
+            if authViewModel.isAuthenticated {
+                if onboardingViewModel.isPaired {
+                    MainAppView()
+                        .environmentObject(onboardingViewModel)
+                } else {
+                    OnboardingFlowView()
+                        .environmentObject(onboardingViewModel)
+                }
+            } else {
+                SignInView()
+            }
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/SignInView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/SignInView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import AuthenticationServices
+
+struct SignInView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var showEmailSignIn = false
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
+
+                // App logo and title
+                VStack(spacing: 8) {
+                    Image(systemName: "house.fill")
+                        .font(.system(size: 64))
+                        .foregroundColor(.blue)
+
+                    Text("HousePulse Lite")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    Text("Smart Home Assistant")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.bottom, 40)
+
+                Spacer()
+
+                // Sign in options
+                VStack(spacing: 16) {
+                    // Apple Sign In
+                    SignInWithAppleButton(
+                        onRequest: { request in
+                            request.requestedScopes = [.email]
+                            request.nonce = authViewModel.generateNonce()
+                        },
+                        onCompletion: { result in
+                            switch result {
+                            case .success(let authorization):
+                                Task {
+                                    await authViewModel.signInWithApple(authorization: authorization)
+                                }
+                            case .failure(let error):
+                                authViewModel.errorMessage = error.localizedDescription
+                            }
+                        }
+                    )
+                    .signInWithAppleButtonStyle(.black)
+                    .frame(height: 50)
+
+                    // Email sign in toggle
+                    Button(action: {
+                        showEmailSignIn.toggle()
+                    }) {
+                        Text(showEmailSignIn ? "Hide Email Sign In" : "Sign in with Email")
+                            .font(.subheadline)
+                            .foregroundColor(.blue)
+                    }
+
+                    // Email sign in form
+                    if showEmailSignIn {
+                        VStack(spacing: 12) {
+                            TextField("Email", text: $email)
+                                .textContentType(.emailAddress)
+                                .autocapitalization(.none)
+                                .padding()
+                                .background(Color(.systemGray6))
+                                .cornerRadius(8)
+
+                            SecureField("Password", text: $password)
+                                .textContentType(.password)
+                                .padding()
+                                .background(Color(.systemGray6))
+                                .cornerRadius(8)
+
+                            Button(action: {
+                                Task {
+                                    await authViewModel.signInWithEmail(
+                                        email: email,
+                                        password: password
+                                    )
+                                }
+                            }) {
+                                Text("Sign In")
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 50)
+                                    .background(Color.blue)
+                                    .cornerRadius(8)
+                            }
+                            .disabled(email.isEmpty || password.isEmpty || authViewModel.isLoading)
+                        }
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+                }
+                .padding(.horizontal)
+
+                // Error message
+                if let errorMessage = authViewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                }
+
+                // Loading indicator
+                if authViewModel.isLoading {
+                    ProgressView()
+                        .padding()
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationBarHidden(true)
+        }
+        .animation(.default, value: showEmailSignIn)
+    }
+}

--- a/ios/HousePulseLite/Package.swift
+++ b/ios/HousePulseLite/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.7
+// This file documents Swift Package dependencies for HousePulse Lite iOS app
+
+import PackageDescription
+
+let package = Package(
+    name: "HousePulseLite",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(
+            name: "HousePulseLite",
+            targets: ["HousePulseLite"]
+        )
+    ],
+    dependencies: [
+        // Note: For a production app, you would typically use:
+        // .package(url: "https://github.com/supabase/supabase-swift", from: "1.0.0")
+        //
+        // For this MVP, we're using URLSession directly for API calls
+        // to minimize dependencies and demonstrate the core flow.
+    ],
+    targets: [
+        .target(
+            name: "HousePulseLite",
+            dependencies: []
+        )
+    ]
+)

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,201 @@
+# HousePulse Lite - iOS App
+
+Native iOS application for HousePulse Lite smart home assistant.
+
+## Requirements
+
+- iOS 16.0+
+- Xcode 14.0+
+- Swift 5.7+
+
+## Architecture
+
+### MVVM Pattern
+- **Models**: Data structures for Home, User, API requests/responses
+- **ViewModels**: Business logic for authentication and onboarding
+- **Views**: SwiftUI user interface components
+- **Services**: Keychain, Supabase client, API communication
+
+### Key Components
+
+#### Authentication
+- **Apple Sign-In**: Primary authentication method using ASAuthorizationController
+- **Email/Password**: Fallback authentication for testing
+- **Supabase Auth**: Backend authentication service
+
+#### Onboarding Flow
+1. **Sign In**: User authenticates with Apple or email
+2. **Home Selection**: User selects from mock home list
+3. **MCP API Key**: User enters MCP API key for home pairing
+4. **Keychain Storage**: API key stored securely in iOS Keychain
+5. **Pair Home**: Calls `/functions/v1/pair_home` edge function
+6. **System Check**: Calls `/functions/v1/system_check` to verify pairing
+7. **Success**: User gains access to main app
+
+## Setup Instructions
+
+### 1. Configure Supabase
+
+Update `ios/HousePulseLite/HousePulseLite/Config/SupabaseConfig.swift`:
+
+```swift
+struct SupabaseConfig {
+    static let url = "https://your-project.supabase.co"
+    static let anonKey = "your-anon-key"
+}
+```
+
+### 2. Enable Sign in with Apple
+
+In Xcode:
+1. Select the HousePulseLite target
+2. Go to "Signing & Capabilities" tab
+3. Click "+ Capability"
+4. Add "Sign in with Apple"
+
+### 3. Configure Bundle Identifier
+
+Update the bundle identifier to match your Apple Developer account:
+1. Select the HousePulseLite target
+2. Go to "Signing & Capabilities"
+3. Update "Bundle Identifier" (e.g., `com.yourcompany.housepulse-lite`)
+
+### 4. Run the App
+
+1. Open `HousePulseLite.xcodeproj` in Xcode
+2. Select a simulator or device
+3. Click Run (⌘R)
+
+## Project Structure
+
+```
+ios/HousePulseLite/HousePulseLite/
+├── HousePulseLiteApp.swift       # App entry point
+├── Config/
+│   └── SupabaseConfig.swift      # Supabase configuration
+├── Models/
+│   ├── Home.swift                # Home data model
+│   ├── User.swift                # User data model
+│   └── APIModels.swift           # API request/response models
+├── Services/
+│   ├── KeychainService.swift     # Secure storage for API keys
+│   └── SupabaseService.swift     # Supabase client & API calls
+├── ViewModels/
+│   ├── AuthViewModel.swift       # Authentication logic
+│   └── OnboardingViewModel.swift # Onboarding flow logic
+└── Views/
+    ├── RootView.swift            # Root navigation
+    ├── SignInView.swift          # Authentication screen
+    ├── OnboardingFlowView.swift  # Onboarding wizard
+    └── MainAppView.swift         # Main app (post-pairing)
+```
+
+## Security Features
+
+### Keychain Storage
+MCP API keys are stored in iOS Keychain with:
+- Service identifier: `com.housepulse.lite`
+- Account key: `mcp_api_key_{homeId}`
+- Accessibility: `kSecAttrAccessibleAfterFirstUnlock`
+
+### Authentication
+- JWT tokens managed by Supabase Auth
+- Tokens included in `Authorization` header for all API calls
+- No plaintext storage of credentials
+
+## API Integration
+
+### Edge Functions
+
+All backend communication uses Supabase Edge Functions:
+
+#### POST /functions/v1/pair_home
+```json
+Request:
+{
+  "home_id": "uuid",
+  "mcp_api_key": "key"
+}
+
+Response:
+{
+  "paired": true
+}
+```
+
+#### POST /functions/v1/system_check
+```json
+Request:
+{
+  "home_id": "uuid"
+}
+
+Response:
+{
+  "ok": true,
+  "last_data_ts": "2026-01-09T12:34:56.789Z",
+  "notes": ["Pairing reference validated", "..."]
+}
+```
+
+## Error Handling
+
+The app handles the following error scenarios:
+- **401 Unauthorized**: User not authenticated or invalid token
+- **403 Forbidden**: User lacks access to home
+- **422 Unprocessable Entity**: Invalid input or home not paired
+- **429 Too Many Requests**: Rate limit exceeded
+- **500 Internal Server Error**: Backend error
+
+Each error displays a user-friendly message with retry option.
+
+## Development Notes
+
+### Mock Data
+- Home list uses mock data (`Home.mockHomes`)
+- Replace with real API calls in production
+
+### Future Enhancements
+- Chat interface integration
+- Sensor data visualization
+- Push notifications
+- Home management (add/remove homes)
+- Settings and preferences
+
+## Testing
+
+### Test Accounts
+Create test users in Supabase Dashboard:
+1. Go to Authentication > Users
+2. Add new user with email/password
+3. Use credentials in email sign-in flow
+
+### Test Flow
+1. Launch app
+2. Sign in with Apple or test email
+3. Select "My Home" from mock list
+4. Enter test MCP API key
+5. Verify pairing succeeds
+6. Check system status displays correctly
+
+## Troubleshooting
+
+### Sign in with Apple fails
+- Ensure capability is enabled in Xcode
+- Check bundle identifier matches Developer Portal
+- Verify Apple ID is configured on device/simulator
+
+### API calls fail
+- Verify Supabase URL and anon key are correct
+- Check network connectivity
+- Review Supabase Edge Function logs
+- Ensure authentication token is valid
+
+### Keychain errors
+- Reset simulator: Device > Erase All Content and Settings
+- Check app has proper entitlements
+- Verify service identifier matches
+
+## License
+
+MIT


### PR DESCRIPTION
- Create native SwiftUI iOS app with iOS 16+ support
- Implement MVVM architecture with clean separation of concerns
- Add Supabase Auth integration (Apple Sign-In primary, email fallback)
- Implement complete onboarding flow:
  1. User authentication (Apple Sign-In with nonce generation)
  2. Home selection (mock home list for MVP)
  3. MCP API key entry
  4. Secure Keychain storage for API keys
  5. Call pair_home edge function
  6. Call system_check edge function
  7. Display success/error states
- Block app access until pairing succeeds
- Add comprehensive error handling with retry functionality
- Implement KeychainService for secure API key storage
- Add SupabaseService for authentication and API calls
- Create AuthViewModel for authentication state management
- Create OnboardingViewModel for pairing flow logic
- Build SwiftUI views:
  - SignInView with Apple Sign-In and email fallback
  - OnboardingFlowView with multi-step wizard
  - HomeSelectionView for choosing home
  - MCPKeyEntryView for pairing
  - MainAppView for post-pairing experience
- No backend code changes (uses existing edge functions)
- Comprehensive documentation in ios/README.md

Refs #4