### PR TITLE
Implement iOS chat screen with quick actions for Issue #5

### DIFF
--- a/ios/HousePulseLite/HousePulseLite/Models/ChatMessage.swift
+++ b/ios/HousePulseLite/HousePulseLite/Models/ChatMessage.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+struct ChatMessage: Identifiable, Codable {
+    let id: UUID
+    let role: String // "user" or "assistant"
+    let content: String
+    let timestamp: Date
+    let toolEvents: [ToolEvent]?
+
+    init(id: UUID = UUID(), role: String, content: String, timestamp: Date = Date(), toolEvents: [ToolEvent]? = nil) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+        self.toolEvents = toolEvents
+    }
+
+    var isUser: Bool {
+        return role == "user"
+    }
+}
+
+struct ToolEvent: Codable, Identifiable {
+    var id: String { tool }
+    let tool: String
+    let status: String
+}
+
+// MARK: - API Models for Chat
+
+struct ChatRequest: Codable {
+    let homeId: String
+    let locale: String
+    let messages: [MessagePayload]
+
+    enum CodingKeys: String, CodingKey {
+        case homeId = "home_id"
+        case locale
+        case messages
+    }
+
+    struct MessagePayload: Codable {
+        let role: String
+        let content: String
+    }
+}
+
+struct ChatResponse: Codable {
+    let reply: String
+    let toolEvents: [ToolEvent]?
+
+    enum CodingKeys: String, CodingKey {
+        case reply
+        case toolEvents = "tool_events"
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/ViewModels/ChatViewModel.swift
+++ b/ios/HousePulseLite/HousePulseLite/ViewModels/ChatViewModel.swift
@@ -1,0 +1,151 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class ChatViewModel: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var currentInput: String = ""
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var showRateLimitHint: Bool = false
+    @Published var dailyMessageCount: Int = 0
+
+    private let supabaseService = SupabaseService.shared
+    private var homeId: String
+    private let locale = "de-DE"
+    private let freeMessageLimit = 50
+
+    init(homeId: String) {
+        self.homeId = homeId
+        loadDailyCount()
+    }
+
+    // Send message to chat API
+    func sendMessage(_ text: String? = nil) async {
+        let messageText = text ?? currentInput.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !messageText.isEmpty else { return }
+
+        // Clear input immediately
+        currentInput = ""
+
+        // Add user message to UI
+        let userMessage = ChatMessage(role: "user", content: messageText)
+        messages.append(userMessage)
+
+        // Set loading state
+        isLoading = true
+        errorMessage = nil
+        showRateLimitHint = false
+
+        do {
+            // Call chat API
+            let response = try await supabaseService.chat(
+                homeId: homeId,
+                locale: locale,
+                messages: messages
+            )
+
+            // Add assistant response
+            let assistantMessage = ChatMessage(
+                role: "assistant",
+                content: response.reply,
+                toolEvents: response.toolEvents
+            )
+            messages.append(assistantMessage)
+
+            // Increment daily count (UX only, server is source of truth)
+            incrementDailyCount()
+
+        } catch SupabaseError.rateLimitExceeded {
+            // Show rate limit hint
+            showRateLimitHint = true
+            errorMessage = "Tageslimit erreicht (50 Nachrichten). Upgrade für unbegrenzte Nachrichten."
+
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // Quick action chips
+    func sendQuickAction(_ action: QuickAction) async {
+        await sendMessage(action.prompt)
+    }
+
+    // Clear error
+    func clearError() {
+        errorMessage = nil
+        showRateLimitHint = false
+    }
+
+    // Daily counter management (client-side UX only)
+    private func loadDailyCount() {
+        let today = getToday()
+        let savedDate = UserDefaults.standard.string(forKey: "lastMessageDate") ?? ""
+        let savedCount = UserDefaults.standard.integer(forKey: "dailyMessageCount")
+
+        if savedDate == today {
+            dailyMessageCount = savedCount
+        } else {
+            dailyMessageCount = 0
+            UserDefaults.standard.set(today, forKey: "lastMessageDate")
+            UserDefaults.standard.set(0, forKey: "dailyMessageCount")
+        }
+    }
+
+    private func incrementDailyCount() {
+        dailyMessageCount += 1
+        UserDefaults.standard.set(dailyMessageCount, forKey: "dailyMessageCount")
+    }
+
+    private func getToday() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    var remainingMessages: Int {
+        return max(0, freeMessageLimit - dailyMessageCount)
+    }
+
+    var usageText: String {
+        return "\(dailyMessageCount)/\(freeMessageLimit) heute"
+    }
+}
+
+// MARK: - Quick Actions
+
+enum QuickAction: String, CaseIterable {
+    case statusCheck = "Status-Check"
+    case risksWarning = "Risiken / Wartung"
+    case energySaving = "Energie sparen"
+    case escoCompliance = "ESCO-Compliance prüfen"
+
+    var prompt: String {
+        switch self {
+        case .statusCheck:
+            return "Zeige mir den aktuellen Status meines Hauses"
+        case .risksWarning:
+            return "Gibt es Wartungsprobleme oder Risiken?"
+        case .energySaving:
+            return "Wie kann ich Energie sparen?"
+        case .escoCompliance:
+            return "Prüfe die ESCO-Compliance"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .statusCheck:
+            return "checkmark.circle.fill"
+        case .risksWarning:
+            return "exclamationmark.triangle.fill"
+        case .energySaving:
+            return "leaf.fill"
+        case .escoCompliance:
+            return "doc.text.magnifyingglass"
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/ChatView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/ChatView.swift
@@ -1,0 +1,281 @@
+import SwiftUI
+
+struct ChatView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @StateObject var chatViewModel: ChatViewModel
+    @State private var showQuickActions = true
+
+    init(homeId: String) {
+        _chatViewModel = StateObject(wrappedValue: ChatViewModel(homeId: homeId))
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Messages list
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(spacing: 8) {
+                            // Welcome message (if no messages)
+                            if chatViewModel.messages.isEmpty {
+                                WelcomeView()
+                                    .padding()
+                            }
+
+                            // Messages
+                            ForEach(chatViewModel.messages) { message in
+                                MessageBubbleView(message: message)
+                                    .id(message.id)
+                            }
+
+                            // Typing indicator
+                            if chatViewModel.isLoading {
+                                TypingIndicatorView()
+                                    .id("typing")
+                            }
+
+                            // Rate limit hint
+                            if chatViewModel.showRateLimitHint {
+                                RateLimitHintView()
+                                    .padding()
+                                    .transition(.scale.combined(with: .opacity))
+                            }
+
+                            // Error message
+                            if let errorMessage = chatViewModel.errorMessage,
+                               !chatViewModel.showRateLimitHint {
+                                ErrorMessageView(message: errorMessage) {
+                                    chatViewModel.clearError()
+                                }
+                                .padding()
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+                    .onChange(of: chatViewModel.messages.count) { _ in
+                        scrollToBottom(proxy: proxy)
+                    }
+                    .onChange(of: chatViewModel.isLoading) { _ in
+                        scrollToBottom(proxy: proxy)
+                    }
+                }
+
+                Divider()
+
+                // Quick action chips (collapsible)
+                if showQuickActions && chatViewModel.messages.isEmpty {
+                    QuickActionsView(chatViewModel: chatViewModel)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
+                // Input area
+                MessageInputView(chatViewModel: chatViewModel)
+            }
+            .navigationTitle("Chat")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "eye.slash.fill")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("Read-Only")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color(.systemGray6))
+                    .cornerRadius(8)
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Text(chatViewModel.usageText)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .animation(.default, value: showQuickActions)
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation {
+                if chatViewModel.isLoading {
+                    proxy.scrollTo("typing", anchor: .bottom)
+                } else if let lastMessage = chatViewModel.messages.last {
+                    proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Welcome View
+
+struct WelcomeView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bubble.left.and.bubble.right.fill")
+                .font(.system(size: 60))
+                .foregroundColor(.blue)
+
+            Text("Willkommen bei HousePulse")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text("Stellen Sie Fragen zu Ihrem Smart Home oder wählen Sie eine Schnellaktion unten.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Quick Actions View
+
+struct QuickActionsView: View {
+    @ObservedObject var chatViewModel: ChatViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Schnellaktionen")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.horizontal)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(QuickAction.allCases, id: \.self) { action in
+                        QuickActionChip(action: action) {
+                            Task {
+                                await chatViewModel.sendQuickAction(action)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+struct QuickActionChip: View {
+    let action: QuickAction
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: action.icon)
+                    .font(.caption)
+                Text(action.rawValue)
+                    .font(.subheadline)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.blue.opacity(0.1))
+            .foregroundColor(.blue)
+            .cornerRadius(20)
+        }
+    }
+}
+
+// MARK: - Message Input View
+
+struct MessageInputView: View {
+    @ObservedObject var chatViewModel: ChatViewModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            TextField("Nachricht eingeben...", text: $chatViewModel.currentInput, axis: .vertical)
+                .textFieldStyle(.plain)
+                .padding(10)
+                .background(Color(.systemGray6))
+                .cornerRadius(20)
+                .lineLimit(1...5)
+                .disabled(chatViewModel.isLoading)
+
+            Button(action: {
+                Task {
+                    await chatViewModel.sendMessage()
+                }
+            }) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 32))
+                    .foregroundColor(chatViewModel.currentInput.isEmpty || chatViewModel.isLoading ? .gray : .blue)
+            }
+            .disabled(chatViewModel.currentInput.isEmpty || chatViewModel.isLoading)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+}
+
+// MARK: - Rate Limit Hint View
+
+struct RateLimitHintView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+                    .font(.title2)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Tageslimit erreicht")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    Text("Sie haben das Tageslimit von 50 Nachrichten erreicht.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .background(Color.orange.opacity(0.1))
+            .cornerRadius(12)
+
+            Text("💡 Tipp: Upgrade für unbegrenzte Nachrichten")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+// MARK: - Error Message View
+
+struct ErrorMessageView: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack {
+            Image(systemName: "exclamationmark.circle.fill")
+                .foregroundColor(.red)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+
+            Spacer()
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .background(Color.red.opacity(0.1))
+        .cornerRadius(12)
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/MessageBubbleView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/MessageBubbleView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct MessageBubbleView: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.isUser {
+                Spacer()
+            }
+
+            VStack(alignment: message.isUser ? .trailing : .leading, spacing: 4) {
+                // Message bubble
+                Text(message.content)
+                    .padding(12)
+                    .background(message.isUser ? Color.blue : Color(.systemGray5))
+                    .foregroundColor(message.isUser ? .white : .primary)
+                    .cornerRadius(16)
+                    .frame(maxWidth: 280, alignment: message.isUser ? .trailing : .leading)
+
+                // Tool events (if any)
+                if let toolEvents = message.toolEvents, !toolEvents.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(toolEvents) { event in
+                            HStack(spacing: 6) {
+                                Image(systemName: event.status == "success" ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .font(.caption2)
+                                    .foregroundColor(event.status == "success" ? .green : .red)
+
+                                Text(event.tool)
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+
+                // Timestamp
+                Text(formatTime(message.timestamp))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 4)
+            }
+
+            if !message.isUser {
+                Spacer()
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 4)
+    }
+
+    private func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Typing Indicator
+
+struct TypingIndicatorView: View {
+    @State private var animating = false
+
+    var body: some View {
+        HStack {
+            HStack(spacing: 4) {
+                ForEach(0..<3) { index in
+                    Circle()
+                        .fill(Color.gray)
+                        .frame(width: 8, height: 8)
+                        .opacity(animating ? 0.3 : 1.0)
+                        .animation(
+                            Animation.easeInOut(duration: 0.6)
+                                .repeatForever()
+                                .delay(Double(index) * 0.2),
+                            value: animating
+                        )
+                }
+            }
+            .padding(12)
+            .background(Color(.systemGray5))
+            .cornerRadius(16)
+
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 4)
+        .onAppear {
+            animating = true
+        }
+    }
+}

--- a/ios/HousePulseLite/HousePulseLite/Views/RootView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/RootView.swift
@@ -7,8 +7,9 @@ struct RootView: View {
     var body: some View {
         Group {
             if authViewModel.isAuthenticated {
-                if onboardingViewModel.isPaired {
-                    MainAppView()
+                if onboardingViewModel.isPaired,
+                   let selectedHome = onboardingViewModel.selectedHome {
+                    ChatView(homeId: selectedHome.id.uuidString)
                         .environmentObject(onboardingViewModel)
                 } else {
                     OnboardingFlowView()

--- a/ios/README.md
+++ b/ios/README.md
@@ -30,7 +30,23 @@ Native iOS application for HousePulse Lite smart home assistant.
 4. **Keychain Storage**: API key stored securely in iOS Keychain
 5. **Pair Home**: Calls `/functions/v1/pair_home` edge function
 6. **System Check**: Calls `/functions/v1/system_check` to verify pairing
-7. **Success**: User gains access to main app
+7. **Success**: User gains access to chat interface
+
+#### Chat Interface
+- **Messenger-style Bubbles**: User messages (blue, right-aligned) vs assistant messages (gray, left-aligned)
+- **Quick Action Chips**: Four German-labeled quick actions:
+  - „Status-Check" - System status inquiry
+  - „Risiken / Wartung" - Risks and maintenance check
+  - „Energie sparen" - Energy saving tips
+  - „ESCO-Compliance prüfen" - ESCO compliance verification
+- **Typing Indicator**: Animated dots while waiting for assistant response
+- **Tool Events**: Display of backend tool executions (e.g., sensor data retrieval)
+- **Rate Limiting**:
+  - Client-side counter displays usage (UX only)
+  - Server enforces 50 messages/day limit
+  - Upgrade hint displayed when limit reached (HTTP 429)
+- **Read-Only Badge**: Indicates current MVP limitations
+- **Usage Counter**: Shows messages used today (e.g., "15/50 heute")
 
 ## Setup Instructions
 
@@ -76,18 +92,22 @@ ios/HousePulseLite/HousePulseLite/
 ├── Models/
 │   ├── Home.swift                # Home data model
 │   ├── User.swift                # User data model
+│   ├── ChatMessage.swift         # Chat message & tool event models
 │   └── APIModels.swift           # API request/response models
 ├── Services/
 │   ├── KeychainService.swift     # Secure storage for API keys
 │   └── SupabaseService.swift     # Supabase client & API calls
 ├── ViewModels/
 │   ├── AuthViewModel.swift       # Authentication logic
-│   └── OnboardingViewModel.swift # Onboarding flow logic
+│   ├── OnboardingViewModel.swift # Onboarding flow logic
+│   └── ChatViewModel.swift       # Chat state & message handling
 └── Views/
     ├── RootView.swift            # Root navigation
     ├── SignInView.swift          # Authentication screen
     ├── OnboardingFlowView.swift  # Onboarding wizard
-    └── MainAppView.swift         # Main app (post-pairing)
+    ├── ChatView.swift            # Main chat interface
+    ├── MessageBubbleView.swift   # Message bubbles & typing indicator
+    └── MainAppView.swift         # Legacy success screen
 ```
 
 ## Security Features
@@ -137,6 +157,29 @@ Response:
   "notes": ["Pairing reference validated", "..."]
 }
 ```
+
+#### POST /functions/v1/chat
+```json
+Request:
+{
+  "home_id": "uuid",
+  "locale": "de-DE",
+  "messages": [
+    { "role": "user", "content": "What is the temperature?" },
+    { "role": "assistant", "content": "The temperature is 21°C" }
+  ]
+}
+
+Response:
+{
+  "reply": "I retrieved the sensor data. Current temperature is 21°C.",
+  "tool_events": [
+    { "tool": "mcp_get_sensor_data", "status": "success" }
+  ]
+}
+```
+
+**Note**: `tool_events` is optional and only included when tools are executed. Rate limit exceeded returns HTTP 429.
 
 ## Error Handling
 


### PR DESCRIPTION
- Add ChatMessage model with tool events support
- Implement ChatViewModel with chat API integration
- Create messenger-style bubble UI (user: blue/right, assistant: gray/left)
- Add typing indicator with animated dots
- Implement four German quick action chips:
  - "Status-Check" - System status inquiry
  - "Risiken / Wartung" - Risks and maintenance
  - "Energie sparen" - Energy saving tips
  - "ESCO-Compliance prüfen" - Compliance verification
- Add chat endpoint integration (POST /functions/v1/chat)
- Handle 429 rate limit errors with upgrade hint
- Implement client-side daily message counter (UX only, server is source of truth)
- Display read-only badge in chat header
- Show usage counter in toolbar (e.g., "15/50 heute")
- Add tool events display in message bubbles
- Implement error handling with dismissible error view
- Add welcome screen for new conversations
- Update RootView to show ChatView as main post-onboarding screen
- Update SupabaseService with chat method and rateLimitExceeded error
- No backend modifications (uses existing edge function)
- Comprehensive documentation in iOS README

Refs #5