### PR TITLE
Add API documentation, privacy policy, and in-app privacy screen for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ Chat-first iOS application for smart building operations.
 
 ## Status
 - Sprint 0: Backend contracts + Chat-only app
+
+## Documentation
+- **[API Documentation](docs/API.md)** - Complete API reference for all edge functions
+- **[Privacy Policy](docs/PRIVACY.md)** - Privacy and data handling (EN + DE)
+- **[iOS App README](ios/README.md)** - iOS app setup and architecture
+
+## Project by Exafion

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,276 @@
+# HousePulse Lite API Documentation
+
+## Overview
+
+HousePulse Lite provides a backend API for smart home assistant functionality via Supabase Edge Functions. All endpoints require authentication with a Supabase JWT token.
+
+**Base URL**: `https://your-project.supabase.co/functions/v1`
+
+## Authentication
+
+All API requests require a valid Supabase JWT token in the `Authorization` header:
+
+```
+Authorization: Bearer <your-jwt-token>
+```
+
+Tokens are obtained through Supabase Auth (Apple Sign-In or email/password authentication).
+
+## Security
+
+- **MCP API keys are never returned** in any API response
+- API keys are hashed (SHA-256) before server-side storage
+- Row Level Security (RLS) ensures users can only access their own data
+- All endpoints validate user authentication before processing
+
+## Endpoints
+
+### POST /pair_home
+
+Pairs a home with the authenticated user by validating and storing an MCP API key reference.
+
+**Authentication**: Required
+
+**Request Body**:
+```json
+{
+  "home_id": "550e8400-e29b-41d4-a716-446655440000",
+  "mcp_api_key": "your-mcp-api-key-here"
+}
+```
+
+**Parameters**:
+- `home_id` (string, required): UUID of the home to pair
+- `mcp_api_key` (string, required): MCP API key for the home (minimum 10 characters)
+
+**Success Response** (200 OK):
+```json
+{
+  "paired": true
+}
+```
+
+**Error Responses**:
+
+| Status Code | Description | Example Response |
+|-------------|-------------|------------------|
+| 401 Unauthorized | Missing or invalid authentication | `{"error": "Missing authorization"}` |
+| 403 Forbidden | User lacks access to home | `{"error": "Forbidden"}` |
+| 422 Unprocessable Entity | Invalid input (missing fields, invalid UUID, invalid MCP key) | `{"error": "Invalid home_id format"}` |
+| 500 Internal Server Error | Server configuration or unexpected errors | `{"error": "Internal server error"}` |
+
+**Notes**:
+- MCP API key is hashed using SHA-256 before storage
+- API key is never stored in plaintext
+- API key is never returned in responses
+- Pairing is bound to both user_id and home_id
+
+---
+
+### POST /system_check
+
+Lightweight health verification for paired homes. Confirms proper pairing and validates backend data access.
+
+**Authentication**: Required
+
+**Request Body**:
+```json
+{
+  "home_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Parameters**:
+- `home_id` (string, required): UUID of the home to check
+
+**Success Response** (200 OK):
+```json
+{
+  "ok": true,
+  "last_data_ts": "2026-01-09T12:34:56.789Z",
+  "notes": [
+    "Pairing reference validated",
+    "System connectivity confirmed",
+    "Paired 5 day(s) ago"
+  ]
+}
+```
+
+**Response Fields**:
+- `ok` (boolean): System health status
+- `last_data_ts` (string): ISO 8601 timestamp of last data update
+- `notes` (array of strings): Human-readable system status messages
+
+**Error Responses**:
+
+| Status Code | Description | Example Response |
+|-------------|-------------|------------------|
+| 401 Unauthorized | Missing or invalid authentication | `{"error": "Invalid authentication"}` |
+| 403 Forbidden | User lacks access to home | `{"error": "Forbidden"}` |
+| 422 Unprocessable Entity | Home not paired to user or invalid input | `{"error": "Home not paired to user"}` |
+| 500 Internal Server Error | Server configuration or unexpected errors | `{"error": "Internal server error"}` |
+
+**Notes**:
+- Requires home to be paired via `/pair_home` first
+- Verifies home belongs to authenticated user
+- Never discloses credentials or API keys
+
+---
+
+### POST /chat
+
+AI chat interface with MCP-based backend tool routing for home automation assistance.
+
+**Authentication**: Required
+
+**Request Body**:
+```json
+{
+  "home_id": "550e8400-e29b-41d4-a716-446655440000",
+  "locale": "de-DE",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the current temperature?"
+    },
+    {
+      "role": "assistant",
+      "content": "The current temperature is 21°C."
+    },
+    {
+      "role": "user",
+      "content": "Thank you"
+    }
+  ]
+}
+```
+
+**Parameters**:
+- `home_id` (string, required): UUID of the home
+- `locale` (string, optional): User's locale preference (e.g., "de-DE", "en-US")
+- `messages` (array, required): Conversation history
+  - Each message must have:
+    - `role` (string): Either "user" or "assistant"
+    - `content` (string): Message text
+
+**Success Response** (200 OK):
+```json
+{
+  "reply": "Understood. How can I help you further?",
+  "tool_events": [
+    {
+      "tool": "mcp_get_sensor_data",
+      "status": "success"
+    }
+  ]
+}
+```
+
+**Response Fields**:
+- `reply` (string): Assistant's textual response
+- `tool_events` (array, optional): Array of tool execution events
+  - `tool` (string): Name of the tool executed
+  - `status` (string): Execution status (e.g., "success", "failed")
+
+**Error Responses**:
+
+| Status Code | Description | Example Response |
+|-------------|-------------|------------------|
+| 401 Unauthorized | Missing or invalid authentication | `{"error": "Missing authorization"}` |
+| 403 Forbidden | User lacks access to home | `{"error": "Forbidden"}` |
+| 422 Unprocessable Entity | Home not paired to user or invalid input | `{"error": "Home not paired to user"}` |
+| 429 Too Many Requests | Free-tier message limit exceeded (50 messages/day) | `{"error": "Free-tier message limit exceeded"}` |
+| 500 Internal Server Error | Server configuration or unexpected errors | `{"error": "Internal server error"}` |
+
+**Rate Limiting**:
+- Free-tier: 50 messages per day per user
+- Enforced server-side with automatic counter tracking
+- Counter resets daily at midnight UTC
+
+**Notes**:
+- Requires home to be paired via `/pair_home` first
+- Streaming is not supported in MVP
+- Tool routing is based on message content
+- Locale-aware responses (supports German and English)
+- Never discloses credentials or API keys
+
+---
+
+## Error Handling
+
+All endpoints follow consistent error response format:
+
+```json
+{
+  "error": "Human-readable error message"
+}
+```
+
+### Common HTTP Status Codes
+
+- **200 OK**: Request successful
+- **401 Unauthorized**: Missing or invalid authentication token
+- **403 Forbidden**: User lacks permission to access resource
+- **422 Unprocessable Entity**: Invalid input or business logic constraint violated
+- **429 Too Many Requests**: Rate limit exceeded
+- **500 Internal Server Error**: Unexpected server error
+
+### Best Practices
+
+1. **Always include Authorization header** with valid JWT token
+2. **Validate input client-side** before sending requests
+3. **Handle rate limits gracefully** - display upgrade messaging for 429 errors
+4. **Implement retry logic** for network errors (not for 4xx errors)
+5. **Never log or display** sensitive data (API keys, tokens)
+
+## Data Privacy
+
+- MCP API keys are **never** returned in API responses
+- API keys are **hashed** (SHA-256) before storage
+- User data is protected by **Row Level Security** (RLS)
+- No tracking or analytics on backend
+- See [PRIVACY.md](PRIVACY.md) for full privacy policy
+
+## Database Schema
+
+### home_pairings
+
+Stores pairing status between users and homes.
+
+```sql
+CREATE TABLE home_pairings (
+  id UUID PRIMARY KEY,
+  home_id UUID NOT NULL,
+  user_id UUID NOT NULL REFERENCES auth.users(id),
+  key_hash TEXT NOT NULL,  -- SHA-256 hash, never plaintext
+  paired_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(home_id, user_id)
+);
+```
+
+### chat_usage
+
+Tracks daily message counts for rate limiting.
+
+```sql
+CREATE TABLE chat_usage (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id),
+  date DATE NOT NULL,
+  message_count INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(user_id, date)
+);
+```
+
+## Support
+
+For issues or questions:
+- GitHub Issues: https://github.com/beikma/housepulse-lite/issues
+- Email: [Contact placeholder - to be added]
+
+---
+
+**Project by Exafion**

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,209 @@
+# Privacy Policy / Datenschutzerklärung
+
+---
+
+## English Version
+
+### HousePulse Lite - Privacy Policy
+
+**Last Updated**: January 2026
+
+**Project by Exafion**
+
+#### Our Commitment to Privacy
+
+HousePulse Lite is designed with privacy as a core principle. We do not track users, serve advertisements, or sell data to third parties.
+
+#### What Data We Process
+
+**Authentication Data**:
+- Managed by Supabase Auth
+- Includes: user ID, email address (if using email authentication), authentication provider (Apple Sign-In or email)
+- Used solely for user authentication and session management
+
+**Home Data**:
+- Home ID (UUID) - to identify which home you're managing
+- Pairing timestamps - to track when homes were connected
+
+**Chat Messages**:
+- Message content sent to the AI assistant
+- Conversation history (stored temporarily during active sessions)
+- Used only to provide chat functionality and context-aware responses
+
+**Usage Counters**:
+- Daily message count per user
+- Used only to enforce free-tier rate limits (50 messages/day)
+- Resets automatically every 24 hours
+
+#### MCP API Key Storage
+
+**Client-Side (iOS)**:
+- MCP API keys are stored securely in the **iOS Keychain**
+- Never stored in plaintext in user defaults or files
+- Protected by iOS system-level encryption
+
+**Server-Side**:
+- API keys are **never stored in plaintext**
+- Keys are hashed using **SHA-256** before storage
+- Hashed keys are used only to validate pairing status
+- Original API keys are **never** logged or returned in responses
+
+#### Logging
+
+- Server logs do not contain secrets or sensitive data
+- Logs include only: timestamps, endpoint names, HTTP status codes, and non-sensitive error messages
+- No API keys, passwords, or personal identifiable information is logged
+
+#### Data Retention
+
+- Authentication data: Retained while your account is active
+- Chat messages: Not permanently stored; used only for active session context
+- Usage counters: Reset daily, historical data not retained
+- Home pairings: Retained until you delete your account or unpair a home
+
+#### Third-Party Services
+
+**Supabase**:
+- Provides authentication, database, and edge function hosting
+- Data is stored in Supabase's infrastructure
+- Subject to [Supabase Privacy Policy](https://supabase.com/privacy)
+
+**No Other Third Parties**:
+- No analytics services (e.g., Google Analytics)
+- No advertising networks
+- No data brokers or marketing platforms
+
+#### Your Rights
+
+You have the right to:
+- Access your data
+- Delete your account and associated data
+- Export your data (upon request)
+- Opt-out of the service at any time
+
+#### Data Security
+
+- All API communications use HTTPS encryption
+- Authentication tokens are managed securely by Supabase
+- Row Level Security (RLS) ensures users can only access their own data
+- MCP API keys never leave your device in plaintext
+
+#### Children's Privacy
+
+HousePulse Lite is not intended for users under 16 years of age. We do not knowingly collect data from children.
+
+#### Changes to This Privacy Policy
+
+We may update this privacy policy from time to time. Significant changes will be communicated through the app or via email.
+
+#### Contact
+
+For privacy-related questions or requests:
+- Email: [Contact email placeholder - to be added]
+- GitHub Issues: https://github.com/beikma/housepulse-lite/issues
+
+**Project by Exafion**
+
+---
+
+## Deutsche Version
+
+### HousePulse Lite - Datenschutzerklärung
+
+**Stand**: Januar 2026
+
+**Ein Projekt von Exafion**
+
+#### Unser Engagement für den Datenschutz
+
+HousePulse Lite wurde mit Datenschutz als Kernprinzip entwickelt. Wir verfolgen keine Benutzer, schalten keine Werbung und verkaufen keine Daten an Dritte.
+
+#### Welche Daten wir verarbeiten
+
+**Authentifizierungsdaten**:
+- Verwaltet von Supabase Auth
+- Umfasst: Benutzer-ID, E-Mail-Adresse (bei E-Mail-Authentifizierung), Authentifizierungsanbieter (Apple Sign-In oder E-Mail)
+- Wird ausschließlich für Benutzerauthentifizierung und Sitzungsverwaltung verwendet
+
+**Heim-Daten**:
+- Heim-ID (UUID) - zur Identifizierung Ihres verwalteten Hauses
+- Kopplungszeitstempel - zur Verfolgung, wann Häuser verbunden wurden
+
+**Chat-Nachrichten**:
+- Nachrichteninhalte, die an den KI-Assistenten gesendet werden
+- Konversationsverlauf (temporär während aktiver Sitzungen gespeichert)
+- Wird nur zur Bereitstellung von Chat-Funktionalität und kontextbewussten Antworten verwendet
+
+**Nutzungszähler**:
+- Tägliche Nachrichtenanzahl pro Benutzer
+- Wird nur zur Durchsetzung der kostenlosen Ratenbegrenzung verwendet (50 Nachrichten/Tag)
+- Wird automatisch alle 24 Stunden zurückgesetzt
+
+#### MCP-API-Schlüssel-Speicherung
+
+**Client-seitig (iOS)**:
+- MCP-API-Schlüssel werden sicher im **iOS Keychain** gespeichert
+- Niemals im Klartext in Benutzereinstellungen oder Dateien gespeichert
+- Geschützt durch iOS-Systemverschlüsselung
+
+**Server-seitig**:
+- API-Schlüssel werden **niemals im Klartext gespeichert**
+- Schlüssel werden mit **SHA-256** gehasht vor der Speicherung
+- Gehashte Schlüssel werden nur zur Validierung des Kopplungsstatus verwendet
+- Original-API-Schlüssel werden **niemals** protokolliert oder in Antworten zurückgegeben
+
+#### Protokollierung
+
+- Server-Logs enthalten keine Geheimnisse oder sensiblen Daten
+- Logs umfassen nur: Zeitstempel, Endpunktnamen, HTTP-Statuscodes und nicht-sensible Fehlermeldungen
+- Keine API-Schlüssel, Passwörter oder persönlich identifizierbaren Informationen werden protokolliert
+
+#### Datenspeicherung
+
+- Authentifizierungsdaten: Werden gespeichert, solange Ihr Konto aktiv ist
+- Chat-Nachrichten: Nicht dauerhaft gespeichert; nur für aktiven Sitzungskontext verwendet
+- Nutzungszähler: Täglich zurückgesetzt, historische Daten nicht gespeichert
+- Heim-Kopplungen: Gespeichert, bis Sie Ihr Konto löschen oder ein Heim entkoppeln
+
+#### Drittanbieter-Dienste
+
+**Supabase**:
+- Bietet Authentifizierung, Datenbank und Edge-Function-Hosting
+- Daten werden in der Infrastruktur von Supabase gespeichert
+- Unterliegt der [Supabase-Datenschutzerklärung](https://supabase.com/privacy)
+
+**Keine weiteren Drittanbieter**:
+- Keine Analysedienste (z.B. Google Analytics)
+- Keine Werbenetzwerke
+- Keine Datenmakler oder Marketing-Plattformen
+
+#### Ihre Rechte
+
+Sie haben das Recht:
+- Auf Zugriff auf Ihre Daten
+- Ihr Konto und zugehörige Daten zu löschen
+- Ihre Daten zu exportieren (auf Anfrage)
+- Sich jederzeit vom Dienst abzumelden
+
+#### Datensicherheit
+
+- Alle API-Kommunikationen verwenden HTTPS-Verschlüsselung
+- Authentifizierungstoken werden sicher von Supabase verwaltet
+- Row Level Security (RLS) stellt sicher, dass Benutzer nur auf ihre eigenen Daten zugreifen können
+- MCP-API-Schlüssel verlassen Ihr Gerät niemals im Klartext
+
+#### Datenschutz für Kinder
+
+HousePulse Lite ist nicht für Benutzer unter 16 Jahren bestimmt. Wir sammeln wissentlich keine Daten von Kindern.
+
+#### Änderungen dieser Datenschutzerklärung
+
+Wir können diese Datenschutzerklärung von Zeit zu Zeit aktualisieren. Wesentliche Änderungen werden über die App oder per E-Mail kommuniziert.
+
+#### Kontakt
+
+Für datenschutzbezogene Fragen oder Anfragen:
+- E-Mail: [Kontakt-E-Mail Platzhalter - wird hinzugefügt]
+- GitHub Issues: https://github.com/beikma/housepulse-lite/issues
+
+**Ein Projekt von Exafion**

--- a/ios/HousePulseLite/HousePulseLite/Views/ChatView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/ChatView.swift
@@ -4,6 +4,7 @@ struct ChatView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @StateObject var chatViewModel: ChatViewModel
     @State private var showQuickActions = true
+    @State private var showPrivacy = false
 
     init(homeId: String) {
         _chatViewModel = StateObject(wrappedValue: ChatViewModel(homeId: homeId))
@@ -90,17 +91,29 @@ struct ChatView: View {
                 }
 
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Text(chatViewModel.usageText)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color(.systemGray6))
-                        .cornerRadius(8)
+                    HStack(spacing: 12) {
+                        Text(chatViewModel.usageText)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color(.systemGray6))
+                            .cornerRadius(8)
+
+                        Button(action: {
+                            showPrivacy = true
+                        }) {
+                            Image(systemName: "info.circle")
+                                .foregroundColor(.blue)
+                        }
+                    }
                 }
             }
         }
         .animation(.default, value: showQuickActions)
+        .sheet(isPresented: $showPrivacy) {
+            PrivacyView()
+        }
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy) {

--- a/ios/HousePulseLite/HousePulseLite/Views/PrivacyView.swift
+++ b/ios/HousePulseLite/HousePulseLite/Views/PrivacyView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+struct PrivacyView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    // Header
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Datenschutz & Daten")
+                            .font(.title)
+                            .fontWeight(.bold)
+
+                        Text("Privacy & Data")
+                            .font(.title3)
+                            .foregroundColor(.secondary)
+
+                        Text("Ein Projekt von Exafion")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.top, 4)
+                    }
+                    .padding(.bottom, 8)
+
+                    Divider()
+
+                    // German Version
+                    PrivacySectionView(
+                        title: "Unser Engagement für den Datenschutz",
+                        content: "HousePulse Lite wurde mit Datenschutz als Kernprinzip entwickelt. Wir verfolgen keine Benutzer, schalten keine Werbung und verkaufen keine Daten an Dritte.",
+                        icon: "hand.raised.fill",
+                        color: .blue
+                    )
+
+                    PrivacySectionView(
+                        title: "Welche Daten wir verarbeiten",
+                        content: """
+                        • Authentifizierungsdaten (Supabase Auth)
+                        • Heim-ID zur Identifizierung Ihres Hauses
+                        • Chat-Nachrichten (temporär für aktive Sitzungen)
+                        • Tägliche Nutzungszähler (50 Nachrichten/Tag)
+                        """,
+                        icon: "doc.text.fill",
+                        color: .green
+                    )
+
+                    PrivacySectionView(
+                        title: "MCP-API-Schlüssel",
+                        content: """
+                        • iOS: Sicher im iOS Keychain gespeichert
+                        • Server: Niemals im Klartext gespeichert
+                        • Gehashed mit SHA-256 vor der Speicherung
+                        • Niemals in API-Antworten zurückgegeben
+                        """,
+                        icon: "key.fill",
+                        color: .orange
+                    )
+
+                    PrivacySectionView(
+                        title: "Keine Verfolgung",
+                        content: """
+                        • Keine Analyse-Dienste (z.B. Google Analytics)
+                        • Keine Werbenetzwerke
+                        • Keine Datenmakler
+                        • Server-Logs enthalten keine Geheimnisse
+                        """,
+                        icon: "eye.slash.fill",
+                        color: .purple
+                    )
+
+                    Divider()
+
+                    // English Version
+                    Text("English Version")
+                        .font(.headline)
+                        .padding(.top, 8)
+
+                    PrivacySectionView(
+                        title: "Our Commitment to Privacy",
+                        content: "HousePulse Lite is designed with privacy as a core principle. We do not track users, serve advertisements, or sell data to third parties.",
+                        icon: "hand.raised.fill",
+                        color: .blue
+                    )
+
+                    PrivacySectionView(
+                        title: "What Data We Process",
+                        content: """
+                        • Authentication data (Supabase Auth)
+                        • Home ID to identify your home
+                        • Chat messages (temporary for active sessions)
+                        • Daily usage counters (50 messages/day)
+                        """,
+                        icon: "doc.text.fill",
+                        color: .green
+                    )
+
+                    PrivacySectionView(
+                        title: "MCP API Key Storage",
+                        content: """
+                        • iOS: Securely stored in iOS Keychain
+                        • Server: Never stored in plaintext
+                        • Hashed with SHA-256 before storage
+                        • Never returned in API responses
+                        """,
+                        icon: "key.fill",
+                        color: .orange
+                    )
+
+                    PrivacySectionView(
+                        title: "No Tracking",
+                        content: """
+                        • No analytics services (e.g., Google Analytics)
+                        • No advertising networks
+                        • No data brokers
+                        • Server logs contain no secrets
+                        """,
+                        icon: "eye.slash.fill",
+                        color: .purple
+                    )
+
+                    Divider()
+
+                    // Contact & Links
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Weitere Informationen / More Information")
+                            .font(.headline)
+
+                        Link(destination: URL(string: "https://github.com/beikma/housepulse-lite")!) {
+                            HStack {
+                                Image(systemName: "link.circle.fill")
+                                Text("GitHub Repository")
+                            }
+                            .foregroundColor(.blue)
+                        }
+
+                        Text("Kontakt / Contact: [E-Mail wird hinzugefügt / Email to be added]")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.top, 8)
+
+                    // Footer
+                    VStack(spacing: 4) {
+                        Text("Projekt von Exafion")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Text("Project by Exafion")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Text("Stand / Last Updated: Januar 2026")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .padding(.top, 4)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 16)
+                }
+                .padding()
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Fertig") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Privacy Section View
+
+struct PrivacySectionView: View {
+    let title: String
+    let content: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .foregroundColor(color)
+                    .font(.title3)
+
+                Text(title)
+                    .font(.headline)
+            }
+
+            Text(content)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6))
+        .cornerRadius(12)
+    }
+}
+
+// MARK: - Preview
+
+struct PrivacyView_Previews: PreviewProvider {
+    static var previews: some View {
+        PrivacyView()
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -47,6 +47,17 @@ Native iOS application for HousePulse Lite smart home assistant.
   - Upgrade hint displayed when limit reached (HTTP 429)
 - **Read-Only Badge**: Indicates current MVP limitations
 - **Usage Counter**: Shows messages used today (e.g., "15/50 heute")
+- **Privacy View**: Accessible via info button in toolbar
+  - Displays privacy policy in German and English
+  - Shows data processing information
+  - Explains MCP API key security
+
+#### Privacy & Data
+- **In-App Privacy Screen**: Bilingual privacy policy accessible from chat toolbar
+- **No Tracking**: No analytics, ads, or data selling
+- **Secure Storage**: MCP API keys stored in iOS Keychain, hashed (SHA-256) server-side
+- **Data Minimization**: Only essential data processed (auth, home_id, messages, usage counters)
+- **Full Transparency**: See [docs/PRIVACY.md](../docs/PRIVACY.md) for complete policy
 
 ## Setup Instructions
 
@@ -107,6 +118,7 @@ ios/HousePulseLite/HousePulseLite/
     ├── OnboardingFlowView.swift  # Onboarding wizard
     ├── ChatView.swift            # Main chat interface
     ├── MessageBubbleView.swift   # Message bubbles & typing indicator
+    ├── PrivacyView.swift         # Privacy & data policy screen
     └── MainAppView.swift         # Legacy success screen
 ```
 


### PR DESCRIPTION
…Issue #6

Documentation:
- Add docs/API.md with complete endpoint documentation
  - POST /functions/v1/pair_home
  - POST /functions/v1/system_check
  - POST /functions/v1/chat
  - Request/response examples with JSON
  - Error codes (401, 403, 422, 429, 500)
  - Authentication requirements (Supabase JWT)
  - Security notes (MCP key never returned, hashed storage)
  - Database schema documentation

- Add docs/PRIVACY.md with bilingual privacy policy
  - English and German (Deutsch) versions
  - No tracking, ads, or data selling
  - Data processed: auth (Supabase), home_id, chat messages, usage counters
  - MCP API key: iOS Keychain storage, SHA-256 hashing server-side
  - Server logs contain no secrets
  - Contact placeholder + "Project by Exafion"

iOS App:
- Add PrivacyView screen
  - Bilingual privacy information (DE + EN)
  - Sections: commitment, data processing, MCP keys, no tracking
  - Accessible via info button in ChatView toolbar
  - Sheet presentation with dismiss button
  - Color-coded sections with icons

- Update ChatView to show privacy screen
  - Add info button (i circle) in toolbar
  - Sheet presentation for PrivacyView
  - No backend modifications

Documentation Updates:
- Update main README.md with documentation links
- Update ios/README.md with privacy section
- Add PrivacyView to project structure

Refs #6